### PR TITLE
Fix import error in certain environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "json-diff-kit",
   "version": "1.0.8",
   "description": "A better JSON differ & viewer.",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "typings": "typings",
   "scripts": {
     "start": "rollup -c -w",


### PR DESCRIPTION
Fixes #4, #9

`"type":  "module"` might also be desirable to indicate that the code is using ESM, and I do have it in my local patch working fine, but not sure if this would interfere with the build process of the package so didn't include it.