### PR TITLE
fix: should handle `null` before `object`

### DIFF
--- a/src/utils/diff-object.ts
+++ b/src/utils/diff-object.ts
@@ -80,6 +80,9 @@ const diffObject = (
         const [resLeft, resRight] = arrayDiffFunc(arrLeft, arrRight, keyLeft, keyRight, level, options, [], []);
         linesLeft = concat(linesLeft, resLeft);
         linesRight = concat(linesRight, resRight);
+      } else if (lhs[keyLeft] === null) {
+        linesLeft.push({ level, type: 'equal', text: `"${keyLeft}": null` });
+        linesRight.push({ level, type: 'equal', text: `"${keyRight}": null` });
       } else if (typeof lhs[keyLeft] === 'object') {
         const result = diffObject(
           lhs[keyLeft],


### PR DESCRIPTION
When `lhs[keyLeft] === null`, it fell into the condition `typeof lhs[keyLeft] === 'object'`, resulting in an error when two `null`s are at the same key in two objects.

Close #22