### PR TITLE
fix(utils): diff-normal should append extra item line-by-line

### DIFF
--- a/playground/playground.tsx
+++ b/playground/playground.tsx
@@ -33,7 +33,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
   const [inlineDiffSeparator, setInlineDiffSeparator] = React.useState(' ');
   const [hideUnchangedLines, setHideUnchangedLines] = React.useState(true);
   const [syntaxHighlight, setSyntaxHighlight] = React.useState(false);
-  const [virtual, setVirtual] = React.useState(true);
+  const [virtual, setVirtual] = React.useState(false);
 
   const differOptions = React.useMemo(() => ({
     detectCircular,

--- a/src/utils/diff-array-lcs.ts
+++ b/src/utils/diff-array-lcs.ts
@@ -162,12 +162,12 @@ const lcs = (
         i--;
         j--;
       } else {
-        const addedLines = stringify(arrLeft[i - 1], undefined, 1).split('\n');
-        for (let i = addedLines.length - 1; i >= 0; i--) {
+        const removedLines = stringify(arrLeft[i - 1], undefined, 1).split('\n');
+        for (let i = removedLines.length - 1; i >= 0; i--) {
           tLeft.unshift({
-            level: level + 1 + (addedLines[i].match(/^\s+/)?.[0]?.length || 0),
+            level: level + 1 + (removedLines[i].match(/^\s+/)?.[0]?.length || 0),
             type: 'remove',
-            text: addedLines[i].replace(/^\s+/, '').replace(/,$/g, ''),
+            text: removedLines[i].replace(/^\s+/, '').replace(/,$/g, ''),
           });
           tRight.unshift({ level: level + 1, type: 'equal', text: '' });
         }

--- a/src/utils/diff-array-normal.ts
+++ b/src/utils/diff-array-normal.ts
@@ -92,12 +92,26 @@ const diffArrayNormal = (
         arrLeft.shift();
         arrRight.shift();
       } else if (arrLeft.length) {
-        linesLeft.push({ level: level + 1, type: 'remove', text: formatValue(itemLeft) });
-        linesRight.push({ level: level + 1, type: 'equal', text: '' });
+        const removedLines = formatValue(itemLeft, undefined, true).split('\n');
+        for (let i = 0; i < removedLines.length; i++) {
+          linesLeft.push({
+            level: level + 1 + (removedLines[i].match(/^\s+/)?.[0]?.length || 0),
+            type: 'remove',
+            text: removedLines[i].replace(/^\s+/, '').replace(/,$/g, ''),
+          });
+          linesRight.push({ level: level + 1, type: 'equal', text: '' });
+        }
         arrLeft.shift();
       } else if (arrRight.length) {
-        linesLeft.push({ level: level + 1, type: 'equal', text: '' });
-        linesRight.push({ level: level + 1, type: 'add', text: formatValue(itemRight) });
+        const addedLines = formatValue(itemRight, undefined, true).split('\n');
+        for (let i = 0; i < addedLines.length; i++) {
+          linesLeft.push({ level: level + 1, type: 'equal', text: '' });
+          linesRight.push({
+            level: level + 1 + (addedLines[i].match(/^\s+/)?.[0]?.length || 0),
+            type: 'add',
+            text: addedLines[i].replace(/^\s+/, '').replace(/,$/g, ''),
+          });
+        }
         arrRight.shift();
       }
     }

--- a/src/utils/is-equal.ts
+++ b/src/utils/is-equal.ts
@@ -1,4 +1,4 @@
-import loIsEqual from 'lodash/isEqual';
+import isEqualWith from 'lodash/isEqualWith';
 import type { DifferOptions } from '../differ';
 
 const isEqual = (a: any, b: any, options: DifferOptions) => {
@@ -6,7 +6,13 @@ const isEqual = (a: any, b: any, options: DifferOptions) => {
     return typeof a === 'string' && typeof b === 'string' && a.toLowerCase() === b.toLowerCase();
   }
   if (options.recursiveEqual) {
-    return loIsEqual(a, b);
+    return isEqualWith(a, b, (a, b) => (
+      options.ignoreCase
+        ? typeof a === 'string' && typeof b === 'string'
+          ? a.toLowerCase() === b.toLowerCase()
+          : undefined
+        : undefined
+    ));
   }
   return a === b;
 };


### PR DESCRIPTION
We used to directly append the `formatValue` result (a string), but it should be a set of prettified lines.

![image](https://github.com/RexSkz/json-diff-kit/assets/27483702/9a6e8285-8df9-43cc-9fcd-84c8b4feb8d9)

Close #24