### PR TITLE
fix(viewer): display a message instead of expand line when no change detected and hideUnchangedLines is true

### DIFF
--- a/src/utils/get-segments.ts
+++ b/src/utils/get-segments.ts
@@ -17,8 +17,8 @@ export interface HiddenUnchangedLinesInfo extends SegmentItem {
   hasLinesAfter: boolean;
 }
 
-const getSegments = (l: DiffResult[], r: DiffResult[], options: HideUnchangedLinesOptions) => {
-  if (!options) {
+const getSegments = (l: DiffResult[], r: DiffResult[], options: HideUnchangedLinesOptions, jsonsAreEqual: boolean) => {
+  if (!options || jsonsAreEqual) {
     return [{ start: 0, end: l.length, isEqual: false }];
   }
 

--- a/src/viewer-monokai.less
+++ b/src/viewer-monokai.less
@@ -22,6 +22,10 @@
     .line-modify {
       background: #444400;
     }
+
+    &.expand-line button {
+      color: #f8f8f2;
+    }
   }
 
   .string {

--- a/src/viewer.less
+++ b/src/viewer.less
@@ -34,6 +34,17 @@
       }
     }
 
+    &.message-line {
+      text-align: center;
+      border-top: 1px solid;
+      border-bottom: 1px solid;
+
+      td {
+        padding: 4px 0;
+        font-size: 12px;
+      }
+    }
+
     &.expand-line {
       text-align: center;
 
@@ -57,7 +68,6 @@
         margin: 0 0.5em;
         padding: 0;
         color: #2196f3;
-        font-family: sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
         font-size: 12px;
         border: none;
         background: transparent;


### PR DESCRIPTION
<img width="415" alt="image" src="https://github.com/RexSkz/json-diff-kit/assets/27483702/f8475f0c-a16e-440c-9d0c-815c7f1bedfb">

Close #30 