### PR TITLE
Add "Compare by Key" Method for Array Diffing

### DIFF
--- a/playground/docs.tsx
+++ b/playground/docs.tsx
@@ -26,6 +26,7 @@ const Docs: React.FC<PropTypes> = props => {
   const [ignoreCase, setIgnoreCase] = React.useState(false);
   const [recursiveEqual, setRecursiveEqual] = React.useState(true);
   const [preserveKeyOrder, setPreserveKeyOrder] = React.useState<DifferOptions['preserveKeyOrder']>(undefined);
+  const [compareKey, setCompareKey] = React.useState<string>('');
 
   // viewer props
   const [indent, setIndent] = React.useState(4);
@@ -44,6 +45,7 @@ const Docs: React.FC<PropTypes> = props => {
     ignoreCase,
     recursiveEqual,
     preserveKeyOrder,
+    compareKey
   }), [
     detectCircular,
     maxDepth,
@@ -52,6 +54,7 @@ const Docs: React.FC<PropTypes> = props => {
     ignoreCase,
     recursiveEqual,
     preserveKeyOrder,
+    compareKey,
   ]);
   const differ = React.useMemo(() => new Differ(differOptions), [differOptions]);
 
@@ -231,9 +234,10 @@ const Docs: React.FC<PropTypes> = props => {
               <option value="lcs">lcs</option>
               <option value="unorder-normal">unorder-normal</option>
               <option value="unorder-lcs">unorder-lcs</option>
+              <option value="compare-key">compare-key</option>
             </select>
           </label>
-          <blockquote>The way to diff arrays, default is <code>"normal"</code>, using <code>"lcs"</code> may get a better result but much slower. <code>"unorder-normal"</code> and <code>"unorder-lcs"</code> are for unordered arrays (the order of elements in the array doesn't matter).</blockquote>
+          <blockquote>The way to diff arrays, default is <code>"normal"</code>, using <code>"lcs"</code> may get a better result but much slower. <code>"unorder-normal"</code> and <code>"unorder-lcs"</code> are for unordered arrays (the order of elements in the array doesn't matter). <code>"compare-key"</code> matches objects by a specific key property.</blockquote>
           <label htmlFor="ignore-case">
             Ignore case:
             <input

--- a/playground/playground.tsx
+++ b/playground/playground.tsx
@@ -28,6 +28,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
   const [ignoreCaseForKey, setIgnoreCaseForKey] = React.useState(false);
   const [recursiveEqual, setRecursiveEqual] = React.useState(true);
   const [preserveKeyOrder, setPreserveKeyOrder] = React.useState<DifferOptions['preserveKeyOrder']>(undefined);
+  const [compareKey, setCompareKey] = React.useState<string>('');
 
   // viewer props
   const [indent, setIndent] = React.useState(4);
@@ -47,6 +48,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
     ignoreCaseForKey,
     recursiveEqual,
     preserveKeyOrder,
+    compareKey: compareKey || undefined,
   }), [
     detectCircular,
     maxDepth,
@@ -56,6 +58,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
     ignoreCaseForKey,
     recursiveEqual,
     preserveKeyOrder,
+    compareKey,
   ]);
   const differ = React.useMemo(() => new Differ(differOptions), [differOptions]);
   const [diff, setDiff] = React.useState(differ.diff('', ''));
@@ -251,7 +254,7 @@ return (
                 title="Array diff method"
                 tip={
                   <>
-                    The way to diff arrays, default is <code>"normal"</code>, using <code>"lcs"</code> may get a better result but much slower. <code>"unorder-normal"</code> and <code>"unorder-lcs"</code> are for unordered arrays (the order of elements in the array doesn't matter).
+                    The way to diff arrays, default is <code>"normal"</code>, using <code>"lcs"</code> may get a better result but much slower. <code>"unorder-normal"</code> and <code>"unorder-lcs"</code> are for unordered arrays (the order of elements in the array doesn't matter). <code>"compare-key"</code> matches objects by a specific key property.
                   </>
                 }
               />
@@ -264,8 +267,24 @@ return (
                 <option value="lcs">lcs</option>
                 <option value="unorder-normal">unorder-normal</option>
                 <option value="unorder-lcs">unorder-lcs</option>
+                <option value="compare-key">compare-key</option>
               </select>
             </label>
+            {arrayDiffMethod === 'compare-key' && (
+              <label htmlFor="compare-key">
+                <Label
+                  title="Compare key"
+                  tip="The key to use for matching objects in arrays. Objects with the same value for this key will be matched and compared, regardless of their position in the array."
+                />
+                <input
+                  type="text"
+                  id="compare-key"
+                  value={compareKey}
+                  onChange={e => setCompareKey(e.target.value)}
+                  placeholder="e.g., oid, userId, id"
+                />
+              </label>
+            )}
             <label htmlFor="ignore-case">
               <Label
                 title="Ignore case"

--- a/src/utils/array-bracket-utils.ts
+++ b/src/utils/array-bracket-utils.ts
@@ -1,0 +1,36 @@
+import type { DiffResult } from '../differ';
+
+// Shared utility for array diff
+export const addArrayOpeningBrackets = (
+  linesLeft: DiffResult[],
+  linesRight: DiffResult[],
+  keyLeft: string,
+  keyRight: string,
+  level: number
+) => {
+  if (keyLeft && keyRight) {
+    linesLeft.push({ level, type: 'equal', text: `"${keyLeft}": [` });
+    linesRight.push({ level, type: 'equal', text: `"${keyRight}": [` });
+  } else {
+    linesLeft.push({ level, type: 'equal', text: '[' });
+    linesRight.push({ level, type: 'equal', text: '[' });
+  }
+};
+
+export const addArrayClosingBrackets = (
+  linesLeft: DiffResult[],
+  linesRight: DiffResult[],
+  level: number
+) => {
+  linesLeft.push({ level, type: 'equal', text: ']' });
+  linesRight.push({ level, type: 'equal', text: ']' });
+};
+
+export const addMaxDepthPlaceholder = (
+  linesLeft: DiffResult[],
+  linesRight: DiffResult[],
+  level: number
+) => {
+  linesLeft.push({ level: level + 1, type: 'equal', text: '...' });
+  linesRight.push({ level: level + 1, type: 'equal', text: '...' });
+}; 

--- a/src/utils/diff-array-compare-key.ts
+++ b/src/utils/diff-array-compare-key.ts
@@ -1,0 +1,197 @@
+import type { DiffResult, DifferOptions } from '../differ';
+import concat from './concat';
+import formatValue from './format-value';
+import diffObject from './diff-object';
+import getType from './get-type';
+import isEqual from './is-equal';
+import prettyAppendLines from './pretty-append-lines';
+import stringify from './stringify';
+import diffArrayNormal from './diff-array-normal';
+
+const diffArrayCompareKey = (
+  arrLeft: any[],
+  arrRight: any[],
+  keyLeft: string,
+  keyRight: string,
+  level: number,
+  options: DifferOptions,
+  linesLeft: DiffResult[] = [],
+  linesRight: DiffResult[] = [],
+): [DiffResult[], DiffResult[]] => {
+  if (!options.compareKey) {
+    // Fallback to normal diff if no compare key is specified
+    return diffArrayNormal(arrLeft, arrRight, keyLeft, keyRight, level, options, linesLeft, linesRight);
+  }
+
+  if (keyLeft && keyRight) {
+    linesLeft.push({ level, type: 'equal', text: `"${keyLeft}": [` });
+    linesRight.push({ level, type: 'equal', text: `"${keyRight}": [` });
+  } else {
+    linesLeft.push({ level, type: 'equal', text: '[' });
+    linesRight.push({ level, type: 'equal', text: '[' });
+  }
+
+  if (level >= (options.maxDepth || Infinity)) {
+    linesLeft.push({ level: level + 1, type: 'equal', text: '...' });
+    linesRight.push({ level: level + 1, type: 'equal', text: '...' });
+  } else {
+    const leftProcessed = new Set<number>();
+    const rightProcessed = new Set<number>();
+    
+    // First pass: find matching objects by compareKey
+    for (let i = 0; i < arrLeft.length; i++) {
+      const leftItem = arrLeft[i];
+      if (leftProcessed.has(i)) continue;
+      
+      // Skip if left item is not an object or doesn't have the compare key
+      if (getType(leftItem) !== 'object' || !(options.compareKey in leftItem)) {
+        continue;
+      }
+      
+      const leftKeyValue = leftItem[options.compareKey];
+      
+      // Find matching item in right array
+      let matchIndex = -1;
+      for (let j = 0; j < arrRight.length; j++) {
+        if (rightProcessed.has(j)) continue;
+        
+        const rightItem = arrRight[j];
+        if (getType(rightItem) !== 'object' || !(options.compareKey in rightItem)) {
+          continue;
+        }
+        
+        const rightKeyValue = rightItem[options.compareKey];
+        
+        // Compare key values
+        if (isEqual(leftKeyValue, rightKeyValue, options)) {
+          matchIndex = j;
+          break;
+        }
+      }
+      
+      if (matchIndex !== -1) {
+        // Found a match, compare the objects
+        const rightItem = arrRight[matchIndex];
+        const leftType = getType(leftItem);
+        const rightType = getType(rightItem);
+        
+        if (leftType !== rightType) {
+          prettyAppendLines(
+            linesLeft,
+            linesRight,
+            '',
+            '',
+            leftItem,
+            rightItem,
+            level + 1,
+            options,
+          );
+        } else if (
+          options.recursiveEqual &&
+          ['object', 'array'].includes(leftType) &&
+          isEqual(leftItem, rightItem, options)
+        ) {
+          prettyAppendLines(
+            linesLeft,
+            linesRight,
+            '',
+            '',
+            leftItem,
+            rightItem,
+            level + 1,
+            options,
+          );
+        } else if (leftType === 'object') {
+          linesLeft.push({ level: level + 1, type: 'equal', text: '{' });
+          linesRight.push({ level: level + 1, type: 'equal', text: '{' });
+          const [leftLines, rightLines] = diffObject(leftItem, rightItem, level + 2, options, diffArrayCompareKey);
+          linesLeft = concat(linesLeft, leftLines);
+          linesRight = concat(linesRight, rightLines);
+          linesLeft.push({ level: level + 1, type: 'equal', text: '}' });
+          linesRight.push({ level: level + 1, type: 'equal', text: '}' });
+        } else if (leftType === 'array') {
+          const [resLeft, resRight] = diffArrayCompareKey(leftItem, rightItem, '', '', level + 1, options, [], []);
+          linesLeft = concat(linesLeft, resLeft);
+          linesRight = concat(linesRight, resRight);
+        } else if (isEqual(leftItem, rightItem, options)) {
+          linesLeft.push({
+            level: level + 1,
+            type: 'equal',
+            text: formatValue(leftItem, undefined, undefined, options.undefinedBehavior),
+          });
+          linesRight.push({
+            level: level + 1,
+            type: 'equal',
+            text: formatValue(rightItem, undefined, undefined, options.undefinedBehavior),
+          });
+        } else {
+          if (options.showModifications) {
+            linesLeft.push({
+              level: level + 1,
+              type: 'modify',
+              text: formatValue(leftItem, undefined, undefined, options.undefinedBehavior),
+            });
+            linesRight.push({
+              level: level + 1,
+              type: 'modify',
+              text: formatValue(rightItem, undefined, undefined, options.undefinedBehavior),
+            });
+          } else {
+            linesLeft.push({
+              level: level + 1,
+              type: 'remove',
+              text: formatValue(leftItem, undefined, undefined, options.undefinedBehavior),
+            });
+            linesLeft.push({ level: level + 1, type: 'equal', text: '' });
+            linesRight.push({ level: level + 1, type: 'equal', text: '' });
+            linesRight.push({
+              level: level + 1,
+              type: 'add',
+              text: formatValue(rightItem, undefined, undefined, options.undefinedBehavior),
+            });
+          }
+        }
+        
+        leftProcessed.add(i);
+        rightProcessed.add(matchIndex);
+      }
+    }
+    
+    // Second pass: handle remaining items (unmatched)
+    for (let i = 0; i < arrLeft.length; i++) {
+      if (leftProcessed.has(i)) continue;
+      
+      const leftItem = arrLeft[i];
+      const removedLines = stringify(leftItem, undefined, 1, undefined, options.undefinedBehavior).split('\n');
+      for (let j = 0; j < removedLines.length; j++) {
+        linesLeft.push({
+          level: level + 1 + (removedLines[j].match(/^\s+/)?.[0]?.length || 0),
+          type: 'remove',
+          text: removedLines[j].replace(/^\s+/, '').replace(/,$/g, ''),
+        });
+        linesRight.push({ level: level + 1, type: 'equal', text: '' });
+      }
+    }
+    
+    for (let i = 0; i < arrRight.length; i++) {
+      if (rightProcessed.has(i)) continue;
+      
+      const rightItem = arrRight[i];
+      const addedLines = stringify(rightItem, undefined, 1, undefined, options.undefinedBehavior).split('\n');
+      for (let j = 0; j < addedLines.length; j++) {
+        linesLeft.push({ level: level + 1, type: 'equal', text: '' });
+        linesRight.push({
+          level: level + 1 + (addedLines[j].match(/^\s+/)?.[0]?.length || 0),
+          type: 'add',
+          text: addedLines[j].replace(/^\s+/, '').replace(/,$/g, ''),
+        });
+      }
+    }
+  }
+
+  linesLeft.push({ level, type: 'equal', text: ']' });
+  linesRight.push({ level, type: 'equal', text: ']' });
+  return [linesLeft, linesRight];
+};
+
+export default diffArrayCompareKey; 

--- a/src/utils/diff-array-compare-key.ts
+++ b/src/utils/diff-array-compare-key.ts
@@ -7,6 +7,7 @@ import isEqual from './is-equal';
 import prettyAppendLines from './pretty-append-lines';
 import stringify from './stringify';
 import diffArrayLCS from './diff-array-lcs';
+import {  addArrayClosingBrackets, addArrayOpeningBrackets, addMaxDepthPlaceholder } from './array-bracket-utils';
 
 const diffArrayCompareKey = (
   arrLeft: any[],
@@ -30,17 +31,10 @@ const diffArrayCompareKey = (
     return diffArrayLCS(arrLeft, arrRight, keyLeft, keyRight, level, options, linesLeft, linesRight);
   }
 
-  if (keyLeft && keyRight) {
-    linesLeft.push({ level, type: 'equal', text: `"${keyLeft}": [` });
-    linesRight.push({ level, type: 'equal', text: `"${keyRight}": [` });
-  } else {
-    linesLeft.push({ level, type: 'equal', text: '[' });
-    linesRight.push({ level, type: 'equal', text: '[' });
-  }
+  addArrayOpeningBrackets(linesLeft, linesRight, keyLeft, keyRight, level)
 
   if (level >= (options.maxDepth || Infinity)) {
-    linesLeft.push({ level: level + 1, type: 'equal', text: '...' });
-    linesRight.push({ level: level + 1, type: 'equal', text: '...' });
+    addMaxDepthPlaceholder(linesLeft, linesRight, level);
   } else {
     const leftProcessed = new Set<number>();
     const rightProcessed = new Set<number>();
@@ -196,8 +190,7 @@ const diffArrayCompareKey = (
     }
   }
 
-  linesLeft.push({ level, type: 'equal', text: ']' });
-  linesRight.push({ level, type: 'equal', text: ']' });
+  addArrayClosingBrackets(linesLeft, linesRight, level)
   return [linesLeft, linesRight];
 };
 

--- a/src/utils/diff-array-compare-key.ts
+++ b/src/utils/diff-array-compare-key.ts
@@ -6,7 +6,7 @@ import getType from './get-type';
 import isEqual from './is-equal';
 import prettyAppendLines from './pretty-append-lines';
 import stringify from './stringify';
-import diffArrayNormal from './diff-array-normal';
+import diffArrayLCS from './diff-array-lcs';
 
 const diffArrayCompareKey = (
   arrLeft: any[],
@@ -20,7 +20,14 @@ const diffArrayCompareKey = (
 ): [DiffResult[], DiffResult[]] => {
   if (!options.compareKey) {
     // Fallback to normal diff if no compare key is specified
-    return diffArrayNormal(arrLeft, arrRight, keyLeft, keyRight, level, options, linesLeft, linesRight);
+    return diffArrayLCS(arrLeft, arrRight, keyLeft, keyRight, level, options, linesLeft, linesRight);
+  }
+
+  // If arrays are not of objects, fallback to unordered LCS diff
+  const isObjectArray = (arr: any[]) => arr.every(item => getType(item) === 'object');
+  if (!isObjectArray(arrLeft) || !isObjectArray(arrRight)) {
+    // Use unordered LCS for arrays of primitives or mixed types
+    return diffArrayLCS(arrLeft, arrRight, keyLeft, keyRight, level, options, linesLeft, linesRight);
   }
 
   if (keyLeft && keyRight) {

--- a/src/utils/diff-array-lcs.ts
+++ b/src/utils/diff-array-lcs.ts
@@ -8,6 +8,7 @@ import isEqual from './is-equal';
 import shallowSimilarity from './shallow-similarity';
 import concat from './concat';
 import prettyAppendLines from './pretty-append-lines';
+import { addArrayClosingBrackets, addArrayOpeningBrackets, addMaxDepthPlaceholder } from './array-bracket-utils';
 
 const lcs = (
   arrLeft: any[],
@@ -208,25 +209,17 @@ const diffArrayLCS = (
   linesLeft: DiffResult[] = [],
   linesRight: DiffResult[] = [],
 ): [DiffResult[], DiffResult[]] => {
-  if (keyLeft && keyRight) {
-    linesLeft.push({ level, type: 'equal', text: `"${keyLeft}": [` });
-    linesRight.push({ level, type: 'equal', text: `"${keyRight}": [` });
-  } else {
-    linesLeft.push({ level, type: 'equal', text: '[' });
-    linesRight.push({ level, type: 'equal', text: '[' });
-  }
+  addArrayOpeningBrackets(linesLeft, linesRight, keyLeft, keyRight, level)
 
   if (level >= (options.maxDepth || Infinity)) {
-    linesLeft.push({ level: level + 1, type: 'equal', text: '...' });
-    linesRight.push({ level: level + 1, type: 'equal', text: '...' });
+    addMaxDepthPlaceholder(linesLeft, linesRight, level);
   } else {
     const [tLeftReverse, tRightReverse] = lcs(arrLeft, arrRight, keyLeft, keyRight, level, options);
     linesLeft = concat(linesLeft, tLeftReverse);
     linesRight = concat(linesRight, tRightReverse);
   }
 
-  linesLeft.push({ level, type: 'equal', text: ']' });
-  linesRight.push({ level, type: 'equal', text: ']' });
+  addArrayClosingBrackets(linesLeft, linesRight, level)
   return [linesLeft, linesRight];
 };
 

--- a/src/utils/diff-array-normal.ts
+++ b/src/utils/diff-array-normal.ts
@@ -8,6 +8,8 @@ import isEqual from './is-equal';
 import prettyAppendLines from './pretty-append-lines';
 import cmp from './cmp';
 import { addArrayClosingBrackets, addArrayOpeningBrackets, addMaxDepthPlaceholder } from './array-bracket-utils';
+import diffArrayCompareKey, { allObjectsHaveCompareKey } from './diff-array-compare-key';
+import { diffObjectWithArraySupport } from './diff-object-with-array-support';
 
 const diffArrayNormal = (
   arrLeft: any[],
@@ -61,15 +63,45 @@ const diffArrayNormal = (
         } else if (leftType === 'object') {
           linesLeft.push({ level: level + 1, type: 'equal', text: '{' });
           linesRight.push({ level: level + 1, type: 'equal', text: '{' });
-          const [leftLines, rightLines] = diffObject(itemLeft, itemRight, level + 2, options, diffArrayNormal);
-          linesLeft = concat(linesLeft, leftLines);
-          linesRight = concat(linesRight, rightLines);
+          let objLeft, objRight;
+          if (options.arrayDiffMethod === 'compare-key') {
+            [objLeft, objRight] = diffObjectWithArraySupport(
+              itemLeft,
+              itemRight,
+              level,
+              options,
+              diffArrayNormal,
+              diffArrayCompareKey,
+              allObjectsHaveCompareKey
+            );
+          } else {
+            [objLeft, objRight] = diffObject(
+              itemLeft,
+              itemRight,
+              level + 2,
+              options,
+              diffArrayNormal
+            );
+          }
+          linesLeft = concat(linesLeft, objLeft);
+          linesRight = concat(linesRight, objRight);
           linesLeft.push({ level: level + 1, type: 'equal', text: '}' });
           linesRight.push({ level: level + 1, type: 'equal', text: '}' });
         } else if (leftType === 'array') {
-          const [resLeft, resRight] = diffArrayNormal(itemLeft, itemRight, '', '', level + 1, options, [], []);
-          linesLeft = concat(linesLeft, resLeft);
-          linesRight = concat(linesRight, resRight);
+          // For nested arrays, check for compare-key logic
+          if (
+            options.compareKey &&
+            allObjectsHaveCompareKey(itemLeft, options.compareKey) &&
+            allObjectsHaveCompareKey(itemRight, options.compareKey)
+          ) {
+            const [resLeft, resRight] = diffArrayCompareKey(itemLeft, itemRight, '', '', level + 1, options, [], []);
+            linesLeft = concat(linesLeft, resLeft);
+            linesRight = concat(linesRight, resRight);
+          } else {
+            const [resLeft, resRight] = diffArrayNormal(itemLeft, itemRight, '', '', level + 1, options, [], []);
+            linesLeft = concat(linesLeft, resLeft);
+            linesRight = concat(linesRight, resRight);
+          }
         } else if (cmp(itemLeft, itemRight, { ignoreCase: options.ignoreCase }) === 0) {
           linesLeft.push({
             level: level + 1,

--- a/src/utils/diff-array-normal.ts
+++ b/src/utils/diff-array-normal.ts
@@ -7,6 +7,7 @@ import getType from './get-type';
 import isEqual from './is-equal';
 import prettyAppendLines from './pretty-append-lines';
 import cmp from './cmp';
+import { addArrayClosingBrackets, addArrayOpeningBrackets, addMaxDepthPlaceholder } from './array-bracket-utils';
 
 const diffArrayNormal = (
   arrLeft: any[],
@@ -20,17 +21,10 @@ const diffArrayNormal = (
 ): [DiffResult[], DiffResult[]] => {
   arrLeft = [...arrLeft];
   arrRight = [...arrRight];
-  if (keyLeft && keyRight) {
-    linesLeft.push({ level, type: 'equal', text: `"${keyLeft}": [` });
-    linesRight.push({ level, type: 'equal', text: `"${keyRight}": [` });
-  } else {
-    linesLeft.push({ level, type: 'equal', text: '[' });
-    linesRight.push({ level, type: 'equal', text: '[' });
-  }
+  addArrayOpeningBrackets(linesLeft, linesRight, keyLeft, keyRight, level)
 
   if (level >= (options.maxDepth || Infinity)) {
-    linesLeft.push({ level: level + 1, type: 'equal', text: '...' });
-    linesRight.push({ level: level + 1, type: 'equal', text: '...' });
+    addMaxDepthPlaceholder(linesLeft, linesRight, level);
   } else {
     while (arrLeft.length || arrRight.length) {
       const itemLeft = arrLeft[0];
@@ -142,8 +136,7 @@ const diffArrayNormal = (
     }
   }
 
-  linesLeft.push({ level, type: 'equal', text: ']' });
-  linesRight.push({ level, type: 'equal', text: ']' });
+  addArrayClosingBrackets(linesLeft, linesRight, level)
   return [linesLeft, linesRight];
 };
 

--- a/src/utils/diff-object-with-array-support.ts
+++ b/src/utils/diff-object-with-array-support.ts
@@ -1,0 +1,97 @@
+import type { DiffResult, DifferOptions } from '../differ';
+import prettyAppendLines from './pretty-append-lines';
+import diffObject from './diff-object';
+import concat from './concat';
+
+/**
+ * Diffs two objects, using compare-key logic for nested arrays if possible.
+ *
+ * @param leftObj The left object
+ * @param rightObj The right object
+ * @param level The current diff level
+ * @param options The diff options
+ * @param fallbackArrayDiff The fallback array diff function (e.g., diffArrayNormal or diffArrayLCS)
+ * @param compareKeyArrayDiff The compare-key array diff function
+ * @param allObjectsHaveCompareKey The function to check if all objects in an array have the compare key
+ * @returns [DiffResult[], DiffResult[]]
+ */
+export function diffObjectWithArraySupport(
+  leftObj: any,
+  rightObj: any,
+  level: number,
+  options: DifferOptions,
+  fallbackArrayDiff: (
+    arrLeft: any[],
+    arrRight: any[],
+    keyLeft: string,
+    keyRight: string,
+    level: number,
+    options: DifferOptions,
+    linesLeft?: DiffResult[],
+    linesRight?: DiffResult[],
+  ) => [DiffResult[], DiffResult[]],
+  compareKeyArrayDiff: (
+    arrLeft: any[],
+    arrRight: any[],
+    keyLeft: string,
+    keyRight: string,
+    level: number,
+    options: DifferOptions,
+    linesLeft?: DiffResult[],
+    linesRight?: DiffResult[],
+  ) => [DiffResult[], DiffResult[]],
+  allObjectsHaveCompareKey: (arr: any[], compareKey: string) => boolean
+): [DiffResult[], DiffResult[]] {
+  let linesLeft: DiffResult[] = [];
+  let linesRight: DiffResult[] = [];
+  const keys = Array.from(new Set([
+    ...Object.keys(leftObj || {}),
+    ...Object.keys(rightObj || {}),
+  ]));
+  for (const key of keys) {
+    const lVal = leftObj ? leftObj[key] : undefined;
+    const rVal = rightObj ? rightObj[key] : undefined;
+    if (Array.isArray(lVal) && Array.isArray(rVal) && options.compareKey) {
+      if (
+        allObjectsHaveCompareKey(lVal, options.compareKey) &&
+        allObjectsHaveCompareKey(rVal, options.compareKey)
+      ) {
+        // Use compare-key diff for this property
+        const [arrL, arrR] = compareKeyArrayDiff(lVal, rVal, '', '', level + 2, options, [], []);
+        linesLeft = concat(linesLeft, arrL);
+        linesRight = concat(linesRight, arrR);
+        continue;
+      }
+    }
+    if (Array.isArray(lVal) && Array.isArray(rVal)) {
+      // Fallback to normal diff for arrays
+      const [arrL, arrR] = fallbackArrayDiff(lVal, rVal, '', '', level + 2, options, [], []);
+      linesLeft = concat(linesLeft, arrL);
+      linesRight = concat(linesRight, arrR);
+    } else if (Array.isArray(lVal) || Array.isArray(rVal)) {
+      // If only one side is array, treat as modification
+      prettyAppendLines(
+        linesLeft,
+        linesRight,
+        key,
+        key,
+        lVal,
+        rVal,
+        level + 2,
+        options,
+      );
+    } else {
+      // Use diffObject for non-array values
+      const [leftLines, rightLines] = diffObject(
+        { [key]: lVal },
+        { [key]: rVal },
+        level + 2,
+        options,
+        fallbackArrayDiff
+      );
+      linesLeft = concat(linesLeft, leftLines);
+      linesRight = concat(linesRight, rightLines);
+    }
+  }
+  return [linesLeft, linesRight];
+} 


### PR DESCRIPTION
### Overview

This PR introduces an additional array diffing mode, compare by key, to have more natural and accurate diffs of arrays with objects that are identified by a unique identifier. Unlike relying on order or value, this method compares objects from arrays based on a provided key (e.g., id) and is therefore perfectly suited for situations where objects' order is not consistent but the object identity is.

### Motivation

This fix addresses issue #49 , where users requested a way to diff arrays of objects by one key rather than by order or whole value comparison. This proves particularly useful when dealing with JSON forms for lists of entities, like users or items, where every object contains a primary key.

### Implementation Details

- **New Method:**  
  - Added `diffArrayCompareKey` in `src/utils/diff-array-compare-key.ts`.
  - Matches objects in arrays by a specified key (`options.compareKey`).
  - Handles nested objects and arrays recursively.
  - Supports existing options like `maxDepth` and `showModifications`.
  - Falls back to the normal diff if no compare key is provided.

- **Behavior:**  
  - Objects with matching keys are compared deeply.
  - Unmatched objects are shown as added or removed.
  - Non-object items or objects missing the key are handled as unmatched.

### Comparison to LCS

Unlike the LCS-based diff, which matches items by value and order, the compare-by-key method is designed for unordered arrays of objects with unique keys, providing more meaningful diffs in such scenarios.

### Closes

- [Issue #49](https://github.com/ekx/my-json-pr/issues/49)

---

Let me know if you want to add usage examples or further technical details!
