### PR TITLE
fix: correct missing array keys in compare-by-key JSON comparison output

### DIFF
--- a/src/utils/diff-array-compare-key.ts
+++ b/src/utils/diff-array-compare-key.ts
@@ -120,7 +120,7 @@ function diffArrayRecursive(
             const rVal = rightItem[key];
             if (Array.isArray(lVal) && Array.isArray(rVal)) {
               // Recursively diff arrays
-              const [arrL, arrR] = diffArrayRecursive(lVal, rVal, '', '', level + 2, options, [], []);
+              const [arrL, arrR] = diffArrayRecursive(lVal, rVal, key, key, level + 2, options, [], []);
               linesLeft = concat(linesLeft, arrL);
               linesRight = concat(linesRight, arrR);
             } else if (Array.isArray(lVal) || Array.isArray(rVal)) {


### PR DESCRIPTION
Hey! I just found a bug on array key display when comparing two JSON objects including arrays. 

As you can see in following image, some arrays were not including keys and showing only braces. I realized I forget to pass keys in line 123, after passing the keys I see no issue with all cases I handled in my previous commit. So that I think the problem will be solved.

Current output:
<img width="1426" height="802" alt="image" src="https://github.com/user-attachments/assets/a26d0912-41fd-4e2e-8d46-aa4fbbcf26c5" />

Expected output after this commit:
<img width="1426" height="802" alt="image" src="https://github.com/user-attachments/assets/3b30876a-6328-454d-bae6-ba48be0da626" />

---
Test JSON object:

`{
  "myUserSet": [
    {
      "oid": "bbdd2194-1ce0-4901-b7a4-8e0a2ebf3f87",
      "userAlternateNameSet": [],
      "userCountrySet": [],
      "subSettingsSet": [
        {
          "oid": "f6074a3e-588b-4f68-832b-1855e43a1416"
        }
      ],
      "userRoleSet": []
    }
  ]
}`

---

> I haven’t opened an issue since this is a minor fix, but I’d be happy to create one if you prefer linking PRs to issues. Let me know if anything needs adjustment

