### PR TITLE
fix(viewer): correct colSpan if no line numbers

### DIFF
--- a/src/viewer.tsx
+++ b/src/viewer.tsx
@@ -409,10 +409,11 @@ const Viewer: React.FC<ViewerProps> = props => {
     const expandMoreLinesLimit = typeof hideUnchangedLines === 'boolean'
       ? DEFAULT_EXPAND_MORE_LINES_LIMIT
       : hideUnchangedLines.expandMoreLinesLimit || DEFAULT_EXPAND_MORE_LINES_LIMIT;
+    const totalColumns = props.lineNumbers ? 4 : 2;
     return [
       <tr key={`expand-line-${index}`} className="expand-line">
         <td
-          colSpan={4}
+          colSpan={totalColumns}
           className={`${hasLinesBefore ? 'has-lines-before' : ''} ${hasLinesAfter ? 'has-lines-after' : ''}`}
         >
           {
@@ -433,9 +434,10 @@ const Viewer: React.FC<ViewerProps> = props => {
 
   const renderTbody = (syntaxHighlightEnabled: boolean) => {
     if (jsonsAreEqual && hideUnchangedLines) {
+      const totalColumns = props.lineNumbers ? 4 : 2;
       return (
         <tr key="message-line" className="message-line">
-          <td colSpan={4}>
+          <td colSpan={totalColumns}>
             {mergedTexts.noChangeDetected}
           </td>
         </tr>
@@ -458,9 +460,10 @@ const Viewer: React.FC<ViewerProps> = props => {
     }
 
     if (firstElementTop > scrollBottom || firstElementTop + totalHeightRef.current < scrollTop) {
+      const totalColumns = props.lineNumbers ? 4 : 2;
       return (
         <tr>
-          <td colSpan={4} style={{ height: `${totalHeightRef.current}px` }} />
+          <td colSpan={totalColumns} style={{ height: `${totalHeightRef.current}px` }} />
         </tr>
       );
     }
@@ -493,17 +496,17 @@ const Viewer: React.FC<ViewerProps> = props => {
     const visibleSegments = segmentsRef.current.slice(startSegment, endSegment + 1);
     return visibleSegments.length ? (
       <>
-        <tr><td colSpan={4} style={{ height: topHeight, padding: 0 }} /></tr>
+        <tr><td colSpan={props.lineNumbers ? 4 : 2} style={{ height: topHeight, padding: 0 }} /></tr>
         {
           visibleSegments.map((segment, index) => (
             renderSegment(segment, index, startLine, endLine, syntaxHighlightEnabled)
           ))
         }
-        <tr><td colSpan={4} style={{ height: bottomHeight, padding: 0 }} /></tr>
+        <tr><td colSpan={props.lineNumbers ? 4 : 2} style={{ height: bottomHeight, padding: 0 }} /></tr>
       </>
     ) : (
       <tr>
-        <td colSpan={4} style={{ height: `${totalHeightRef.current}px` }} />
+        <td colSpan={props.lineNumbers ? 4 : 2} style={{ height: `${totalHeightRef.current}px` }} />
       </tr>
     );
   };

--- a/src/viewer.tsx
+++ b/src/viewer.tsx
@@ -166,6 +166,7 @@ const Viewer: React.FC<ViewerProps> = props => {
   const scrollContainer = _scrollContainer === 'body'
     ? document.body
     : document.querySelector(_scrollContainer);
+  const totalColumns = props.lineNumbers ? 4 : 2;
 
   // Use these refs to keep the diff data and segments sync,
   // or it may cause runtime error because of their mismatch.
@@ -409,7 +410,6 @@ const Viewer: React.FC<ViewerProps> = props => {
     const expandMoreLinesLimit = typeof hideUnchangedLines === 'boolean'
       ? DEFAULT_EXPAND_MORE_LINES_LIMIT
       : hideUnchangedLines.expandMoreLinesLimit || DEFAULT_EXPAND_MORE_LINES_LIMIT;
-    const totalColumns = props.lineNumbers ? 4 : 2;
     return [
       <tr key={`expand-line-${index}`} className="expand-line">
         <td
@@ -434,7 +434,6 @@ const Viewer: React.FC<ViewerProps> = props => {
 
   const renderTbody = (syntaxHighlightEnabled: boolean) => {
     if (jsonsAreEqual && hideUnchangedLines) {
-      const totalColumns = props.lineNumbers ? 4 : 2;
       return (
         <tr key="message-line" className="message-line">
           <td colSpan={totalColumns}>
@@ -460,7 +459,6 @@ const Viewer: React.FC<ViewerProps> = props => {
     }
 
     if (firstElementTop > scrollBottom || firstElementTop + totalHeightRef.current < scrollTop) {
-      const totalColumns = props.lineNumbers ? 4 : 2;
       return (
         <tr>
           <td colSpan={totalColumns} style={{ height: `${totalHeightRef.current}px` }} />
@@ -496,17 +494,17 @@ const Viewer: React.FC<ViewerProps> = props => {
     const visibleSegments = segmentsRef.current.slice(startSegment, endSegment + 1);
     return visibleSegments.length ? (
       <>
-        <tr><td colSpan={props.lineNumbers ? 4 : 2} style={{ height: topHeight, padding: 0 }} /></tr>
+        <tr><td colSpan={totalColumns} style={{ height: topHeight, padding: 0 }} /></tr>
         {
           visibleSegments.map((segment, index) => (
             renderSegment(segment, index, startLine, endLine, syntaxHighlightEnabled)
           ))
         }
-        <tr><td colSpan={props.lineNumbers ? 4 : 2} style={{ height: bottomHeight, padding: 0 }} /></tr>
+        <tr><td colSpan={totalColumns} style={{ height: bottomHeight, padding: 0 }} /></tr>
       </>
     ) : (
       <tr>
-        <td colSpan={props.lineNumbers ? 4 : 2} style={{ height: `${totalHeightRef.current}px` }} />
+        <td colSpan={totalColumns} style={{ height: `${totalHeightRef.current}px` }} />
       </tr>
     );
   };


### PR DESCRIPTION
Previously colSpan for all td's that are meant to span the entire table is 4 (one for each of the content columns, one for each of the line number columns). If you don't have line numbers, that should be 2.