### PR TITLE
fix: infinite loop when object has an empty string key

### DIFF
--- a/src/differ.spec.ts
+++ b/src/differ.spec.ts
@@ -1,6 +1,22 @@
 import Differ from './differ';
 
 describe('object diff', () => {
+  it('should not infinite loop when an object has an empty string key', () => {
+    const l = { '': 'before', a: 1 };
+    const r = { '': 'after', b: 2 };
+    const d = new Differ();
+    // Should complete without hanging or throwing
+    expect(() => d.diff(l, r)).not.toThrow();
+    const result = d.diff(l, r);
+    // Both sides must have the same number of lines
+    expect(result[0].length).toBe(result[1].length);
+    // The empty-string key's value change should appear as a modification
+    const leftTypes = result[0].map(line => line.type);
+    const rightTypes = result[1].map(line => line.type);
+    expect(leftTypes).toContain('modify');
+    expect(rightTypes).toContain('modify');
+  });
+
   it('preserve key order', () => {
     const l = { a: 1, b: 2, c: 3 };
     const r = { c: 3, b: 2, d: 4, a: 1 };

--- a/src/utils/diff-object.ts
+++ b/src/utils/diff-object.ts
@@ -181,9 +181,9 @@ const diffObject = (
       }
     }
 
-    if (!keyLeft) {
+    if (keyLeft === undefined) {
       keysRight.shift();
-    } else if (!keyRight) {
+    } else if (keyRight === undefined) {
       keysLeft.shift();
     } else if (keyCmpResult === 0) {
       keysLeft.shift();


### PR DESCRIPTION
## Problem

When diffing two objects where either side contains an empty string (`""`) as a key, `diffObject` enters an infinite loop and exhausts all available memory, crashing the process/browser tab.

The root cause is the key-advance logic at the end of the `while` loop:

```ts
if (!keyLeft) {
  keysRight.shift();
} else if (!keyRight) {
  keysLeft.shift();
```

Because `!''` is `true` in JavaScript, when the current left key is the empty string the code thinks the left side is exhausted and only advances the right pointer. `keysLeft` is therefore never shifted past `""`, and once `keysRight` drains the loop spins forever.

## Fix

Replace the falsy checks with strict `=== undefined` comparisons:

```ts
if (keyLeft === undefined) {
  keysRight.shift();
} else if (keyRight === undefined) {
  keysLeft.shift();
```

## Test

A regression test is added to `differ.spec.ts` that diffs two objects both containing an empty-string key and asserts: the call completes without throwing, both sides produce the same number of lines, and the changed value is marked as a modification.

## Reproduction

```ts
const d = new Differ();
// Hangs / OOMs before this fix:
d.diff({ '': 'before', a: 1 }, { '': 'after', b: 2 });
```